### PR TITLE
Added a autowired CommentService in the AbstractRepoIntegrationTest.java

### DIFF
--- a/repo/src/main/java/org/redpill/alfresco/test/AbstractRepoIntegrationTest.java
+++ b/repo/src/main/java/org/redpill/alfresco/test/AbstractRepoIntegrationTest.java
@@ -21,6 +21,7 @@ import org.alfresco.repo.security.authentication.AuthenticationUtil.RunAsWork;
 import org.alfresco.repo.site.SiteModel;
 import org.alfresco.repo.transaction.RetryingTransactionHelper;
 import org.alfresco.repo.transaction.RetryingTransactionHelper.RetryingTransactionCallback;
+import org.alfresco.repo.forum.CommentService;
 import org.alfresco.service.cmr.model.FileFolderService;
 import org.alfresco.service.cmr.model.FileInfo;
 import org.alfresco.service.cmr.repository.ContentService;
@@ -90,6 +91,10 @@ public abstract class AbstractRepoIntegrationTest implements InstanceTestClassLi
   @Autowired
   @Qualifier("NodeService")
   protected NodeService _nodeService;
+  
+  @Autowired
+  @Qualifier("CommentService")
+  protected CommentService _commentService;
 
   @Autowired
   @Qualifier("FileFolderService")


### PR DESCRIPTION
Hello, 
We need to test the commentService so I have added that to the AbstractRepoIT. 
NB.
This little trivial addition could not be tested local due to depencies issues,
[ERROR] Failed to execute goal on project alfresco-test-repo: Could not resolve dependencies for project org.redpill-linpro.alfresco:alfresco-test-repo:jar:1.0.3:
 Could not find artifact org.alfresco:alfresco-repository:jar:4.2.2 in redpill-linpro (http://maven.redpill-linpro.com/nexus/content/groups/public) -
